### PR TITLE
Auth events & improvements

### DIFF
--- a/src/main/java/com/dqu/simplerauth/PlayerObject.java
+++ b/src/main/java/com/dqu/simplerauth/PlayerObject.java
@@ -3,7 +3,7 @@ package com.dqu.simplerauth;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 public class PlayerObject {
-    private final ServerPlayerEntity player;
+    private ServerPlayerEntity player;
     private boolean authenticated;
 
     public PlayerObject(ServerPlayerEntity player) {
@@ -11,12 +11,8 @@ public class PlayerObject {
         this.authenticated = false;
     }
 
-    public void authenticate(ServerPlayerEntity player) {
-        player.setInvulnerable(false);
-        this.authenticated = true;
-    }
-
     public void authenticate() {
+        this.player.setInvulnerable(false);
         this.authenticated = true;
     }
 
@@ -26,6 +22,12 @@ public class PlayerObject {
 
     public ServerPlayerEntity getPlayer() {
         return player;
+    }
+
+    public void updatePlayer(ServerPlayerEntity player) {
+        if (this.player != player) {
+            this.player = player;
+        }
     }
 
     public void destroy() {

--- a/src/main/java/com/dqu/simplerauth/PlayerObject.java
+++ b/src/main/java/com/dqu/simplerauth/PlayerObject.java
@@ -12,11 +12,10 @@ public class PlayerObject {
     }
 
     public void authenticate(ServerPlayerEntity player) {
-        if (!player.isCreative()) player.setInvulnerable(false);
+        player.setInvulnerable(false);
         this.authenticated = true;
     }
 
-    @Deprecated
     public void authenticate() {
         this.authenticated = true;
     }

--- a/src/main/java/com/dqu/simplerauth/api/event/PlayerAuthEvents.java
+++ b/src/main/java/com/dqu/simplerauth/api/event/PlayerAuthEvents.java
@@ -1,0 +1,55 @@
+package com.dqu.simplerauth.api.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public final class PlayerAuthEvents {
+    /**
+     * Called when a player logs in.
+     */
+    public static final Event<PlayerLogin> PLAYER_LOGIN = EventFactory.createArrayBacked(PlayerLogin.class, callbacks -> (player, via) -> {
+        for (PlayerLogin callback : callbacks) {
+            callback.onPlayerLogin(player, via);
+        }
+    });
+
+    /**
+     * Called when a player fails the password.
+     */
+    public static final Event<PlayerLoginFail> PLAYER_LOGIN_FAIL = EventFactory.createArrayBacked(PlayerLoginFail.class, callbacks -> (player, fails) -> {
+        for (PlayerLoginFail callback : callbacks) {
+            callback.onPlayerLoginFail(player, fails);
+        }
+    });
+
+    /**
+     * Called when a player registers.
+     */
+    public static final Event<PlayerRegister> PLAYER_REGISTER = EventFactory.createArrayBacked(PlayerRegister.class, callbacks -> player -> {
+        for (PlayerRegister callback : callbacks) {
+            callback.onPlayerRegister(player);
+        }
+    });
+
+    @FunctionalInterface
+    public interface PlayerLogin {
+        /**
+         * Called when a player logs in.
+         * 
+         * @param player the player
+         * @param via loginCommand, onlineAuth, session, permissionLevel
+         */
+        void onPlayerLogin(ServerPlayerEntity player, String via);
+    }
+
+    @FunctionalInterface
+    public interface PlayerLoginFail {
+        void onPlayerLoginFail(ServerPlayerEntity player, int fails);
+    }
+
+    @FunctionalInterface
+    public interface PlayerRegister {
+        void onPlayerRegister(ServerPlayerEntity player);
+    }
+}

--- a/src/main/java/com/dqu/simplerauth/commands/LoginCommand.java
+++ b/src/main/java/com/dqu/simplerauth/commands/LoginCommand.java
@@ -7,6 +7,9 @@ import com.dqu.simplerauth.managers.LangManager;
 import com.dqu.simplerauth.PlayerObject;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.Vec3d;
@@ -18,61 +21,62 @@ public class LoginCommand {
     public static void registerCommand(CommandDispatcher<ServerCommandSource> dispatcher) {
         dispatcher.register(literal("login")
             .then(argument("password", StringArgumentType.word())
-                .executes(ctx -> {
-                    String password = StringArgumentType.getString(ctx, "password");
-                    String username = ctx.getSource().getPlayer().getEntityName();
-                    ServerPlayerEntity player = ctx.getSource().getPlayer();
-                    PlayerObject playerObject = AuthMod.playerManager.get(player);
-                    String passwordtype = ConfigManager.getAuthType();
-
-                    if (playerObject.isAuthenticated()) {
-                        ctx.getSource().sendFeedback(LangManager.getLiteralText("command.login.alreadylogged"), false);
-                        return 1;
-                    }
-
-                    if (passwordtype.equals("local")) {
-                        // Local Password Authentication
-
-                        if (!DbManager.isPlayerRegistered(username)) {
-                            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.login.notregistered"), false);
-                            return 1;
-                        }
-
-                        if (DbManager.isPasswordCorrect(username, password)) {
-                            playerObject.authenticate(player);
-                            if (ConfigManager.getBoolean("sessions-enabled"))
-                                DbManager.sessionCreate(player.getEntityName(), player.getIp());
-                            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.authenticated"), false);
-                        } else {
-                            player.networkHandler.disconnect(LangManager.getLiteralText("command.general.notmatch"));
-                        }
-                    } else if (passwordtype.equals("global")) {
-                        // Global Password Authentication
-                        String globalPassword = ConfigManager.getString("global-password");
-
-                        if (password.equals(globalPassword)) {
-                            playerObject.authenticate(player);
-                            if (ConfigManager.getBoolean("sessions-enabled"))
-                                DbManager.sessionCreate(player.getEntityName(), player.getIp());
-                            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.authenticated"), false);
-                        } else {
-                            player.networkHandler.disconnect(LangManager.getLiteralText("command.general.notmatch"));
-                        }
-                    } else {
-                        // Config setup is wrong, kick the player
-                        player.networkHandler.disconnect(LangManager.getLiteralText("config.incorrect"));
-                    }
-
-                    boolean hideposition = ConfigManager.getBoolean("hide-position");
-                    if (hideposition) {
-                        Vec3d pos = DbManager.getPosition(username);
-                        if (pos != null)
-                            player.requestTeleport(pos.getX(), pos.getY(), pos.getZ());
-                    }
-
-                    return 1;
-                })
+                .executes(ctx -> login(ctx))
             )
         );
+    }
+
+    private static int login(CommandContext<ServerCommandSource> ctx) throws CommandSyntaxException {
+        ServerPlayerEntity player = ctx.getSource().getPlayer();
+        PlayerObject playerObject = AuthMod.playerManager.get(player);
+
+        if (playerObject.isAuthenticated()) {
+            throw new SimpleCommandExceptionType(LangManager.getLiteralText("command.login.alreadylogged")).create();
+        }
+
+        String password = StringArgumentType.getString(ctx, "password");
+        String username = player.getEntityName();
+        
+        if (!isPasswordCorrect(username, password)) {
+            // TODO: fails and kick after x fails
+            player.networkHandler.disconnect(LangManager.getLiteralText("command.general.notmatch"));
+            return 0;
+        }
+        playerObject.authenticate(player);
+        if (ConfigManager.getBoolean("sessions-enabled")) {
+            DbManager.sessionCreate(player.getEntityName(), player.getIp());
+        }
+        ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.authenticated"), false);
+        if (ConfigManager.getBoolean("hide-position")) {
+            Vec3d pos = DbManager.getPosition(username);
+            if (pos != null)
+                player.requestTeleport(pos.getX(), pos.getY(), pos.getZ());
+        }
+        return 1;
+    }
+
+    private static boolean isPasswordCorrect(String username, String password) throws CommandSyntaxException {
+        switch (ConfigManager.getAuthType()) {
+            case "local" -> {
+                // Local Password Authentication
+                if (!DbManager.isPlayerRegistered(username)) {
+                    throw new SimpleCommandExceptionType(LangManager.getLiteralText("command.login.notregistered")).create();
+                }
+                if (DbManager.isPasswordCorrect(username, password)) {
+                    return true;
+                }
+            }
+            case "global" -> {
+                // Global Password Authentication
+                if (password.equals(ConfigManager.getString("global-password"))) {
+                    return true;
+                }
+            }
+            default -> {
+                // Config setup is wrong
+                throw new SimpleCommandExceptionType(LangManager.getLiteralText("config.incorrect")).create();
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/dqu/simplerauth/commands/LoginCommand.java
+++ b/src/main/java/com/dqu/simplerauth/commands/LoginCommand.java
@@ -42,7 +42,7 @@ public class LoginCommand {
             player.networkHandler.disconnect(LangManager.getLiteralText("command.general.notmatch"));
             return 0;
         }
-        playerObject.authenticate(player);
+        playerObject.authenticate();
         if (ConfigManager.getBoolean("sessions-enabled")) {
             DbManager.sessionCreate(player.getEntityName(), player.getIp());
         }

--- a/src/main/java/com/dqu/simplerauth/commands/LoginCommand.java
+++ b/src/main/java/com/dqu/simplerauth/commands/LoginCommand.java
@@ -5,6 +5,7 @@ import com.dqu.simplerauth.managers.ConfigManager;
 import com.dqu.simplerauth.managers.DbManager;
 import com.dqu.simplerauth.managers.LangManager;
 import com.dqu.simplerauth.PlayerObject;
+import com.dqu.simplerauth.api.event.PlayerAuthEvents;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
@@ -39,10 +40,12 @@ public class LoginCommand {
         
         if (!isPasswordCorrect(username, password)) {
             // TODO: fails and kick after x fails
+            PlayerAuthEvents.PLAYER_LOGIN_FAIL.invoker().onPlayerLoginFail(player, 1);
             player.networkHandler.disconnect(LangManager.getLiteralText("command.general.notmatch"));
             return 0;
         }
         playerObject.authenticate();
+        PlayerAuthEvents.PLAYER_LOGIN.invoker().onPlayerLogin(player, "loginCommand");
         if (ConfigManager.getBoolean("sessions-enabled")) {
             DbManager.sessionCreate(player.getEntityName(), player.getIp());
         }

--- a/src/main/java/com/dqu/simplerauth/commands/RegisterCommand.java
+++ b/src/main/java/com/dqu/simplerauth/commands/RegisterCommand.java
@@ -59,7 +59,7 @@ public class RegisterCommand {
 
                         DbManager.addPlayerDatabase(username, password);
                         PlayerObject playerObject = AuthMod.playerManager.get(player);
-                        playerObject.authenticate(player);
+                        playerObject.authenticate();
                         ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.authenticated"), false);
                         return 1;
                     })

--- a/src/main/java/com/dqu/simplerauth/commands/RegisterCommand.java
+++ b/src/main/java/com/dqu/simplerauth/commands/RegisterCommand.java
@@ -7,6 +7,8 @@ import com.dqu.simplerauth.managers.LangManager;
 import com.dqu.simplerauth.PlayerObject;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -21,50 +23,52 @@ public class RegisterCommand {
         dispatcher.register(literal("register")
             .then(argument("password", StringArgumentType.word())
                 .then(argument("repeatPassword", StringArgumentType.word())
-                    .executes(ctx -> {
-                        String password = StringArgumentType.getString(ctx, "password");
-                        String passwordRepeat = StringArgumentType.getString(ctx, "repeatPassword");
-                        ServerPlayerEntity player = ctx.getSource().getPlayer();
-                        String username = player.getEntityName();
-                        String authtype = ConfigManager.getAuthType();
-
-                        if (authtype.equals("global")) {
-                            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.globaltype"), false);
-                            return 1;
-                        } else if (authtype.equals("none")) {
-                            player.networkHandler.disconnect(LangManager.getLiteralText("config.incorrect"));
-                        }
-
-                        if (DbManager.isPlayerRegistered(username)) {
-                            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.alreadyregistered"), false);
-                            return 1;
-                        }
-
-                        if (!password.equals(passwordRepeat)) {
-                            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.notmatch"), false);
-                            return 1;
-                        }
-
-                        try {
-                            Pattern regex = Pattern.compile(ConfigManager.getString("password-regex"));
-                            Matcher matcher = regex.matcher(password);
-                            if (!matcher.matches()) {
-                                ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.passweak"), false);
-                                return 1;
-                            }
-                        } catch (Exception e) {
-                            AuthMod.LOGGER.error(LangManager.get("config.incorrect"));
-                            AuthMod.LOGGER.warn("Skipping regex password validation as the config is incorrect.");
-                        }
-
-                        DbManager.addPlayerDatabase(username, password);
-                        PlayerObject playerObject = AuthMod.playerManager.get(player);
-                        playerObject.authenticate();
-                        ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.authenticated"), false);
-                        return 1;
-                    })
+                    .executes(ctx -> register(ctx))
                 )
             )
         );
+    }
+
+    private static int register(CommandContext<ServerCommandSource> ctx) throws CommandSyntaxException {
+        String password = StringArgumentType.getString(ctx, "password");
+        String passwordRepeat = StringArgumentType.getString(ctx, "repeatPassword");
+        ServerPlayerEntity player = ctx.getSource().getPlayer();
+        String username = player.getEntityName();
+        String authtype = ConfigManager.getAuthType();
+
+        if (authtype.equals("global")) {
+            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.globaltype"), false);
+            return 1;
+        } else if (authtype.equals("none")) {
+            player.networkHandler.disconnect(LangManager.getLiteralText("config.incorrect"));
+        }
+
+        if (DbManager.isPlayerRegistered(username)) {
+            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.alreadyregistered"), false);
+            return 1;
+        }
+
+        if (!password.equals(passwordRepeat)) {
+            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.notmatch"), false);
+            return 1;
+        }
+
+        try {
+            Pattern regex = Pattern.compile(ConfigManager.getString("password-regex"));
+            Matcher matcher = regex.matcher(password);
+            if (!matcher.matches()) {
+                ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.passweak"), false);
+                return 1;
+            }
+        } catch (Exception e) {
+            AuthMod.LOGGER.error(LangManager.get("config.incorrect"));
+            AuthMod.LOGGER.warn("Skipping regex password validation as the config is incorrect.");
+        }
+
+        DbManager.addPlayerDatabase(username, password);
+        PlayerObject playerObject = AuthMod.playerManager.get(player);
+        playerObject.authenticate();
+        ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.authenticated"), false);
+        return 1;
     }
 }

--- a/src/main/java/com/dqu/simplerauth/commands/RegisterCommand.java
+++ b/src/main/java/com/dqu/simplerauth/commands/RegisterCommand.java
@@ -5,10 +5,12 @@ import com.dqu.simplerauth.managers.ConfigManager;
 import com.dqu.simplerauth.managers.DbManager;
 import com.dqu.simplerauth.managers.LangManager;
 import com.dqu.simplerauth.PlayerObject;
+import com.dqu.simplerauth.api.event.PlayerAuthEvents;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -30,35 +32,33 @@ public class RegisterCommand {
     }
 
     private static int register(CommandContext<ServerCommandSource> ctx) throws CommandSyntaxException {
-        String password = StringArgumentType.getString(ctx, "password");
-        String passwordRepeat = StringArgumentType.getString(ctx, "repeatPassword");
+        String authtype = ConfigManager.getAuthType();
+        
+        if (authtype.equals("global")) {
+            throw new SimpleCommandExceptionType(LangManager.getLiteralText("command.register.globaltype")).create();
+        } else if (authtype.equals("none")) {
+            throw new SimpleCommandExceptionType(LangManager.getLiteralText("config.incorrect")).create();
+        }
+        
         ServerPlayerEntity player = ctx.getSource().getPlayer();
         String username = player.getEntityName();
-        String authtype = ConfigManager.getAuthType();
-
-        if (authtype.equals("global")) {
-            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.globaltype"), false);
-            return 1;
-        } else if (authtype.equals("none")) {
-            player.networkHandler.disconnect(LangManager.getLiteralText("config.incorrect"));
-        }
-
+        
         if (DbManager.isPlayerRegistered(username)) {
-            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.alreadyregistered"), false);
-            return 1;
+            throw new SimpleCommandExceptionType(LangManager.getLiteralText("command.register.alreadyregistered")).create();
         }
+        
+        String password = StringArgumentType.getString(ctx, "password");
+        String passwordRepeat = StringArgumentType.getString(ctx, "repeatPassword");
 
         if (!password.equals(passwordRepeat)) {
-            ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.notmatch"), false);
-            return 1;
+            throw new SimpleCommandExceptionType(LangManager.getLiteralText("command.general.notmatch")).create();
         }
 
         try {
             Pattern regex = Pattern.compile(ConfigManager.getString("password-regex"));
             Matcher matcher = regex.matcher(password);
             if (!matcher.matches()) {
-                ctx.getSource().sendFeedback(LangManager.getLiteralText("command.register.passweak"), false);
-                return 1;
+                throw new SimpleCommandExceptionType(LangManager.getLiteralText("command.register.passweak")).create();
             }
         } catch (Exception e) {
             AuthMod.LOGGER.error(LangManager.get("config.incorrect"));
@@ -68,6 +68,7 @@ public class RegisterCommand {
         DbManager.addPlayerDatabase(username, password);
         PlayerObject playerObject = AuthMod.playerManager.get(player);
         playerObject.authenticate();
+        PlayerAuthEvents.PLAYER_REGISTER.invoker().onPlayerRegister(player);
         ctx.getSource().sendFeedback(LangManager.getLiteralText("command.general.authenticated"), false);
         return 1;
     }

--- a/src/main/java/com/dqu/simplerauth/listeners/OnPlayerConnect.java
+++ b/src/main/java/com/dqu/simplerauth/listeners/OnPlayerConnect.java
@@ -2,6 +2,7 @@ package com.dqu.simplerauth.listeners;
 
 import com.dqu.simplerauth.AuthMod;
 import com.dqu.simplerauth.PlayerObject;
+import com.dqu.simplerauth.api.event.PlayerAuthEvents;
 import com.dqu.simplerauth.managers.CacheManager;
 import com.dqu.simplerauth.managers.ConfigManager;
 import com.dqu.simplerauth.managers.DbManager;
@@ -32,6 +33,7 @@ public class OnPlayerConnect {
 
         if (!player.hasPermissionLevel(ConfigManager.getInt("require-auth-permission-level"))) {
             playerObject.authenticate();
+            PlayerAuthEvents.PLAYER_LOGIN.invoker().onPlayerLogin(player, "permissionLevel");
             return;
         }
 
@@ -41,6 +43,7 @@ public class OnPlayerConnect {
         // Forced online authentication does not require registration
         if ((forcedOnlineAuth || (optionalOnlineAuth && DbManager.isPlayerRegistered(player.getEntityName()))) && testPlayerOnline(player) && !isGlobalAuth) {
             playerObject.authenticate();
+            PlayerAuthEvents.PLAYER_LOGIN.invoker().onPlayerLogin(player, "onlineAuth");
             player.sendMessage(LangManager.getLiteralText("command.general.authenticated"), false);
             AuthMod.LOGGER.info(player.getEntityName() + " is using an online account, authenticated automatically.");
             return;
@@ -49,6 +52,7 @@ public class OnPlayerConnect {
         if (ConfigManager.getBoolean("sessions-enabled")) {
             if (DbManager.sessionVerify(player.getEntityName(), player.getIp())) {
                 playerObject.authenticate();
+                PlayerAuthEvents.PLAYER_LOGIN.invoker().onPlayerLogin(player, "session");
                 DbManager.sessionCreate(player.getEntityName(), player.getIp());
                 player.sendMessage(LangManager.getLiteralText("command.general.authenticated"), false);
                 return;

--- a/src/main/java/com/dqu/simplerauth/listeners/OnPlayerConnect.java
+++ b/src/main/java/com/dqu/simplerauth/listeners/OnPlayerConnect.java
@@ -25,9 +25,10 @@ public class OnPlayerConnect {
 
     public static void listen(ServerPlayerEntity player) {
         PlayerObject playerObject = AuthMod.playerManager.get(player);
+        playerObject.updatePlayer(player);
 
         if (!player.hasPermissionLevel(ConfigManager.getInt("require-auth-permission-level"))) {
-            playerObject.authenticate(player);
+            playerObject.authenticate();
             return;
         }
 
@@ -36,7 +37,7 @@ public class OnPlayerConnect {
         boolean isGlobalAuth = ConfigManager.getAuthType().equals("global");
         // Forced online authentication does not require registration
         if ((forcedOnlineAuth || (optionalOnlineAuth && DbManager.isPlayerRegistered(player.getEntityName()))) && testPlayerOnline(player) && !isGlobalAuth) {
-            playerObject.authenticate(player);
+            playerObject.authenticate();
             player.sendMessage(LangManager.getLiteralText("command.general.authenticated"), false);
             AuthMod.LOGGER.info(player.getEntityName() + " is using an online account, authenticated automatically.");
             return;
@@ -44,7 +45,7 @@ public class OnPlayerConnect {
 
         if (ConfigManager.getBoolean("sessions-enabled")) {
             if (DbManager.sessionVerify(player.getEntityName(), player.getIp())) {
-                playerObject.authenticate(player);
+                playerObject.authenticate();
                 DbManager.sessionCreate(player.getEntityName(), player.getIp());
                 player.sendMessage(LangManager.getLiteralText("command.general.authenticated"), false);
                 return;


### PR DESCRIPTION
Add [auth events](https://github.com/Dqu1J/simplerauth/blob/461200345e1aff1422a80cd262ed440bdee1b548/src/main/java/com/dqu/simplerauth/api/event/PlayerAuthEvents.java) which other mods can listen as #9 says.
Events:
- `PLAYER_LOGIN`: called when a player logs in (can be via loginCommand, onlineAuth, session or permissionLevel)
- `PLAYER_LOGIN_FAIL`: called when a player fails the password
- `PLAYER_REGISTER`: called when a player registers

To use the events in a mod just add Simpler auth to `dependencies` in `build.gradle`

In `/login` and `/register` instead of sending an error with `sendFeedback()` and then returning 1, now throw `SimpleCommandExceptionType`.
Returning 1 means that the command executed successfully, so that's why I changed it.

When a player joins, the player object inside the `PlayerObject` class now gets updated so I removed `authenticate(player)`